### PR TITLE
Update JSONT.tmLanguage

### DIFF
--- a/Syntaxes/JSONT.tmLanguage
+++ b/Syntaxes/JSONT.tmLanguage
@@ -299,6 +299,7 @@
           <string>(date|pluralize|truncate|video)</string>
         </dict>
       </array>
+    </dict>
   </dict>
   <key>scopeName</key>
   <string>text.html.jsont</string>
@@ -306,3 +307,4 @@
   <key>uuid</key>
   <string>12f1ad07-29ae-4b1d-9a95-0712a46d5ec6</string>
 </dict>
+</plist>


### PR DESCRIPTION
I've added a couple of missing XML tags on the syntax file. Sublime no longer gives me an error when switching to the `HTML (JSON-T)` syntax. Unfortunately, there is no functional syntax highlighting either.

@stormwarning perhaps you can use this as a starting point and investigate the missing highlighting? I have no experience with Sublime syntax highlighting plugins, I just ran this through an XML validator. :)

Closes #1
